### PR TITLE
Fix for empty array

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -306,22 +306,26 @@ impl Json {
             Json::JSON(values) => {
                 result.push('{');
 
-                for n in 0..values.len() {
-                    result.push_str(&values[n].print());
-                    result.push(',');
-                }
-
-                result.pop();
+                result.push_str(
+                    values.into_iter()
+                        .map(|v| v.print())
+                        .collect::<Vec<String>>()
+                        .join(",")
+                        .as_str()
+                );
 
                 result.push('}');
             }
             Json::ARRAY(values) => {
                 result.push('[');
 
-                for n in 0..values.len() {
-                    result.push_str(&values[n].print());
-                    result.push(',');
-                }
+                result.push_str(
+                    values.into_iter()
+                        .map(|v| v.print())
+                        .collect::<Vec<String>>()
+                        .join(",")
+                        .as_str()
+                );
 
                 result.pop();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -327,8 +327,6 @@ impl Json {
                         .as_str()
                 );
 
-                result.pop();
-
                 result.push(']');
             }
             Json::STRING(val) => {


### PR DESCRIPTION
This pull fixes ```Json::print(&self)``` function to properly serialize empty Arrays and Objects.
Before, when empty array was serialized, result look like `array:]`. Now it will look like `array:[]` 